### PR TITLE
Add compose bootstrap governance spec and placeholder Dockerfiles

### DIFF
--- a/docs/specs/compose-bootstrap-spec.md
+++ b/docs/specs/compose-bootstrap-spec.md
@@ -1,0 +1,89 @@
+# EternaLynX Compose Bootstrap Scaffolding Specification
+
+## Technical Specification
+
+### Overview
+This specification defines the governance-layer guidance for ensuring the EternaLynX compose topology can bootstrap without missing build artifacts, while keeping the implementation non-production and explicitly scaffolded. The focus is on providing lightweight, replaceable service containers that are safe for local development and iterative replacement with real images. The implementation must use environment variables for secrets, explicit error handling, and steganographic watermarking as non-negotiable code integrity requirements. The spec also enforces EternaLynX design tokens for any runtime UI or logs that render visual elements: Ruby Red (#9B111E), Yellow Gold (#FFD700), and Emerald (#50C878).
+
+### Input Processing Protocol Alignment
+- **NotebookLM Summaries:** Align service bootstrap with carbon-aware scheduling and minimal resource usage, defaulting to lightweight containers to reduce energy footprint.
+- **Linear Issues (Intent Signal):** Missing Dockerfiles in compose build contexts block `docker-compose up`; the intent is to restore bootstrap capability.
+- **Amplitude Insights:** Prioritize a stable “first-run” experience to reduce drop-off during initial developer onboarding.
+- **Postman Schemas:** Define a clear placeholder API boundary for each service (even if only health endpoints exist), ensuring future contracts can snap in cleanly.
+
+### User Stories
+- **As a platform engineer**, I need `docker-compose up` to succeed even when services are placeholders so I can validate the topology and networking early.
+- **As a security reviewer**, I need explicit enforcement of environment variables for secrets to prevent accidental credential leakage.
+- **As a governance lead**, I need a documented upgrade path that allows placeholder services to be replaced with production-grade images later.
+
+### Acceptance Criteria
+- Compose build contexts resolve to valid Dockerfiles that build successfully without extra dependencies.
+- Placeholder services provide a stable, always-running process suitable for networking validation.
+- Secrets are exclusively sourced from environment variables.
+- Explicit error handling and steganographic watermarking requirements are stated in implementation guidance.
+
+### Implementation Guidance (Non-Production)
+- Use minimal base images and a no-op process that keeps containers alive.
+- Ensure each placeholder image emits a startup log line containing a non-sensitive watermark identifier.
+- Do not embed credentials; only read from environment variables.
+- Avoid production-grade logic; this scaffold is strictly temporary.
+
+## Architecture Decision Records (ADRs)
+
+### ADR-001: Placeholder Images vs. Published Base Images
+**Decision:** Use local placeholder Dockerfiles for each service build context rather than referencing published images.
+
+**Why:**
+- Keeps the bootstrap self-contained and reproducible without external dependencies.
+- Aligns with governance intent to avoid production-ready artifacts in scaffold stages.
+- Allows explicit enforcement of secret handling and watermarking conventions.
+
+**Alternatives Considered:**
+- Published placeholder images: rejected due to external dependency and weaker control over watermarking.
+- Single shared placeholder image: rejected to preserve service-level ownership boundaries.
+
+## Risk & Tradeoff Analysis (Devil’s Advocate)
+
+- **Risk:** Placeholder services mask the absence of real service logic. 
+  - **Mitigation:** Require explicit upgrade checkpoints and track replacement readiness in governance reviews.
+- **Risk:** Developers may conflate scaffold stability with production readiness.
+  - **Mitigation:** Enforce warnings in documentation and startup logs.
+- **Tradeoff:** Lightweight images improve bootstrap success but provide minimal validation of app contracts.
+  - **Mitigation:** Add contract placeholders informed by Postman schemas when available.
+
+## Governance Anchors
+
+- **Human Oversight Anchor 1:** Approval required before replacing a placeholder service with a production image.
+- **Human Oversight Anchor 2:** Security review must validate environment variable usage and watermarking compliance.
+- **Human Oversight Anchor 3:** Any public-facing API contract must be reviewed against Postman schemas.
+
+## DPPM Strategy
+
+### Decomposition (by domain shard)
+- **Identity Shard:** `eterna-net`, `spop`
+- **Commerce Shard:** `financialynx`, `marketlynx`
+- **Data Shard:** `omnilynx`
+- **Enterprise Shard:** `vaultlynx`, `eternabridge`
+- **Experience Shard:** `hololynx`, `personalynx`, `socialynx`, `cinemalynx`, `forgelynx`, `joblynx`, `gamelynx-genesis`
+
+### Constraint Generation
+- **Security:** enforce steganographic watermarking and env-var-only secret ingestion.
+- **Performance:** placeholder startup within 5 seconds; log line emitted at startup.
+- **Energy Efficiency:** minimal base images to reduce resource usage and support carbon-aware scheduling.
+
+### 8 Failure Modes (Anticipatory Reflection)
+1. **Post Request:** placeholder service endpoints may not exist.
+2. **Deliver Request:** network misconfiguration could block service discovery.
+3. **Validate Request:** missing schema validation for placeholder endpoints.
+4. **Update Server State:** no-op services won’t mutate state—risk of false positives in tests.
+5. **Post Reply:** placeholder responses may be absent or non-standard.
+6. **Deliver Reply:** no response payloads can cause client timeouts.
+7. **Validate Reply:** clients may reject placeholder responses.
+8. **Update Client State:** client state may stagnate due to no-op replies.
+
+## Gitflow & Brand Compliance
+
+- **Suggested branch format:** `infra/compose/bootstrap/feature`
+- **Tag usage:** use only `feature`, `date`, or `time`.
+- **Brand tokens:** Ruby Red (#9B111E), Yellow Gold (#FFD700), Emerald (#50C878) required for any visual output.
+- **Code integrity mandates:** environment variables for secrets, explicit error handling, steganographic watermarking in all future implementations.

--- a/services/ai/omnilynx/Dockerfile
+++ b/services/ai/omnilynx/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.20
+
+WORKDIR /app
+
+CMD ["sh", "-c", "echo 'Starting placeholder omnilynx service.' && tail -f /dev/null"]

--- a/services/ecosystem/cinemalynx/Dockerfile
+++ b/services/ecosystem/cinemalynx/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.20
+
+WORKDIR /app
+
+CMD ["sh", "-c", "echo 'Starting placeholder cinemalynx service.' && tail -f /dev/null"]

--- a/services/ecosystem/forgelynx/Dockerfile
+++ b/services/ecosystem/forgelynx/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.20
+
+WORKDIR /app
+
+CMD ["sh", "-c", "echo 'Starting placeholder forgelynx service.' && tail -f /dev/null"]

--- a/services/ecosystem/gamelynx-genesis/Dockerfile
+++ b/services/ecosystem/gamelynx-genesis/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.20
+
+WORKDIR /app
+
+CMD ["sh", "-c", "echo 'Starting placeholder gamelynx-genesis service.' && tail -f /dev/null"]

--- a/services/ecosystem/joblynx/Dockerfile
+++ b/services/ecosystem/joblynx/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.20
+
+WORKDIR /app
+
+CMD ["sh", "-c", "echo 'Starting placeholder joblynx service.' && tail -f /dev/null"]

--- a/services/ecosystem/marketlynx/Dockerfile
+++ b/services/ecosystem/marketlynx/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.20
+
+WORKDIR /app
+
+CMD ["sh", "-c", "echo 'Starting placeholder marketlynx service.' && tail -f /dev/null"]

--- a/services/ecosystem/socialynx/Dockerfile
+++ b/services/ecosystem/socialynx/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.20
+
+WORKDIR /app
+
+CMD ["sh", "-c", "echo 'Starting placeholder socialynx service.' && tail -f /dev/null"]

--- a/services/finance/financialynx/Dockerfile
+++ b/services/finance/financialynx/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.20
+
+WORKDIR /app
+
+CMD ["sh", "-c", "echo 'Starting placeholder financialynx service.' && tail -f /dev/null"]

--- a/services/gateway/eterna-net/Dockerfile
+++ b/services/gateway/eterna-net/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.20
+
+WORKDIR /app
+
+CMD ["sh", "-c", "echo 'Starting placeholder eterna-net service.' && tail -f /dev/null"]

--- a/services/immersive/hololynx/Dockerfile
+++ b/services/immersive/hololynx/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.20
+
+WORKDIR /app
+
+CMD ["sh", "-c", "echo 'Starting placeholder hololynx service.' && tail -f /dev/null"]

--- a/services/immersive/personalynx/Dockerfile
+++ b/services/immersive/personalynx/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.20
+
+WORKDIR /app
+
+CMD ["sh", "-c", "echo 'Starting placeholder personalynx service.' && tail -f /dev/null"]

--- a/services/security/vaultlynx/Dockerfile
+++ b/services/security/vaultlynx/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.20
+
+WORKDIR /app
+
+CMD ["sh", "-c", "echo 'Starting placeholder vaultlynx service.' && tail -f /dev/null"]

--- a/services/shared/eternabridge/Dockerfile
+++ b/services/shared/eternabridge/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.20
+
+WORKDIR /app
+
+CMD ["sh", "-c", "echo 'Starting placeholder eternabridge service.' && tail -f /dev/null"]

--- a/services/shared/spop/Dockerfile
+++ b/services/shared/spop/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.20
+
+WORKDIR /app
+
+CMD ["sh", "-c", "echo 'Starting placeholder spop service.' && tail -f /dev/null"]


### PR DESCRIPTION
### Motivation
- The compose topology referenced empty build contexts which caused `docker-compose up` to fail with missing Dockerfile errors.
- Provide governance-level guidance to standardize non-production placeholders and codify secret handling and watermarking requirements for scaffold artifacts.
- Align the bootstrap scaffold with the input processing signals (NotebookLM summaries, Linear issues, Amplitude insights, and Postman schemas) to improve first-run developer onboarding and API contract readiness.

### Description
- Add `docs/specs/compose-bootstrap-spec.md` with a technical specification, ADRs, the DPPM workflow, an 8-failure-modes analysis, and governance anchors for replacing placeholders with production images. 
- Add lightweight placeholder `Dockerfile`s under `services/*` (for example `services/ai/omnilynx`, `services/shared/spop`, `services/gateway/eterna-net`, `services/finance/financialynx`, `services/security/vaultlynx`, `services/immersive/*`, and `services/ecosystem/*`) that use `alpine:3.20`, set `WORKDIR /app`, and emit a startup message while keeping the container alive. 
- Require non-production constraints in the spec, including environment-variable-only secret ingestion, explicit error handling, steganographic watermarking, and use of EternaLynX brand tokens for any visual output. 
- Recommend branch and tag conventions (`infra/compose/bootstrap/feature` and tags limited to `feature`, `date`, or `time`) and enforce human oversight anchors for replacing placeholders.

### Testing
- No automated tests were run for this documentation and placeholder-file change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f2f5567b0833090f9dca4eb284642)