### PR TITLE
Add LMCL architecture blueprint spec

### DIFF
--- a/docs/specs/lmcl-blueprint.md
+++ b/docs/specs/lmcl-blueprint.md
@@ -1,0 +1,184 @@
+# LynxVerse Multimodal Context Layer (LMCL) Blueprint
+
+## 0) Scope, Inputs, and Assumptions
+
+**Task Source (Linear/NotebookLM placeholder):** The prompt requests a design blueprint for the LynxVerse Multimodal Context Layer (LMCL) with phased implementation, DAG-anchored trust, and multimodal fusion. The provided task field is blank, so this document treats the prompt itself as the authoritative intent signal.
+
+**Input Streams Required by Governance:**
+- **NotebookLM Summaries:** Not supplied. This spec aligns with current industry trends (multimodal fusion, zero-trust, edge offload) as assumed context.
+- **Linear Issues:** Not supplied. The prompt is treated as the primary intent signal.
+- **Amplitude Insights:** Not supplied. Feature prioritization is derived from the prompt’s critical paths (trust validation, latency, multimodal fusion).
+- **Postman Schemas:** Not supplied. API boundaries are defined as interface contracts with placeholders for future schema binding.
+
+**Assumptions:**
+- EternaLynX runs a DAG-based trust network (ChainLynX) and isolated containerized microservices linked via LynxVerse Bridging Protocols.
+- Redis and PostgreSQL are the canonical state/session stores.
+- VaultLynX is the system of record for DIDs and device bindings.
+
+**Non-Goals:**
+- This document intentionally does **not** include production-ready code. It specifies architecture, interfaces, and decision rationale only.
+
+---
+
+## 1) Technical Specification
+
+### 1.1 Mission Statement
+Design the **LynxVerse Multimodal Context Layer (LMCL)** as a high-speed middleware responsible for multimodal context fusion and zero-trust, DAG-anchored authorization before routing any request within the EternaLynX ecosystem.
+
+### 1.2 DPPM Reasoning Loop
+
+#### Decomposition (Sub-goals)
+1. **Identity & Trust Shard**: DID verification, DAG trust proofs, compliance veto.
+2. **Multimodal Fusion Shard**: input normalization, ordering, context object construction.
+3. **Routing & BFF Shard**: service abstraction, policy-based routing, session management.
+4. **Offload & Orchestration Shard**: GPU rendering offload, agent task decomposition.
+5. **Observability & Governance Shard**: audit trails, human oversight anchors.
+
+#### Constraint Generation
+- **Security**: Zero Trust Architecture, ephemeral sessions, DID-device binding, and steganographic watermarking in payloads for forensic traceability.
+- **Performance**: end-to-end latency budget targeting <20ms motion-to-photon for XR paths; asynchronous processing for non-critical paths.
+- **Energy Efficiency**: carbon-aware scheduling for offload workloads (prefer nearby low-carbon regions if available).
+
+#### Anticipatory Reflection: 8 Failure Modes
+1. **Post Request**: malformed or spoofed modalities; mitigation: adapter validation + DID binding.
+2. **Deliver Request**: bridge latency or dropped messages; mitigation: retries + circuit breakers.
+3. **Validate Request**: DAG lookup unavailable or delayed; mitigation: cache with strict TTL + fail-closed for high-risk.
+4. **Update Server State**: inconsistent session state; mitigation: Redis atomic operations + idempotency keys.
+5. **Post Reply**: data leakage in responses; mitigation: payload redaction policies.
+6. **Deliver Reply**: response misrouting; mitigation: BFF routing with source scoping.
+7. **Validate Reply**: corrupted or unauthenticated response; mitigation: response signatures + integrity checks.
+8. **Update Client State**: stale UX context; mitigation: versioned context objects and client-side reconciliation.
+
+### 1.3 Canonical Context Object Schema (v1.0)
+**Schema format:** JSON/TypeScript definition (spec-level, non-implementation).
+
+**Required Fields:**
+- `SourceID`: DID + device signature (VaultLynX validated).
+- `Timestamp`: UTC + Lamport clock.
+- `InputModality`: enumerated modality type (e.g., VoiceCommand, Gesture_Gaze, Agent_ToolCall).
+- `SpatialAnchorID`: spatial anchor reference if applicable.
+- `Payload`: normalized modality payload.
+- `ChainLynX_Proof`: placeholder for DAG verification hash.
+
+**Versioning:** `ContextObject_v1.0` with forward compatibility strategy (additive fields only).
+
+### 1.4 LMCL Modules & Responsibilities
+
+#### A) LMCL-Input (Adapters)
+- **GestureInputAdapter**: normalizes hand-tracking/gesture streams.
+- **VoiceNLPAdapter**: normalizes ASR/NLP transcripts.
+- **AgentToolCallAdapter**: normalizes LLM tool calls.
+
+#### B) LMCL-Core (Trust & Routing)
+- **DagTrustValidator**: async DAG lookups for identity + compliance checks with hard-deny for ambiguous high-risk actions.
+- **FusionEngine**: merges multimodal inputs via hybrid timestamp ordering into a single coherent context object.
+- **Router (BFF)**: routes validated context to internal microservices, abstracting service topology.
+
+#### C) LMCL-Services (Offload & Orchestration)
+- **RenderOffload**: intercepts heavy render requests to remote GPU services; streams output via WebRTC/SFU paths.
+- **AgentTaskOrchestrator**: decomposes complex tasks into atomic tool calls using LLM agent frameworks (placeholder).
+
+### 1.5 Integration Mapping (LMCL Responsibility Matrix)
+- **DigiFriend**: multimodal avatar interactions; veto for personality compliance.
+- **DigiLawyer**: context fusion for legal prompts; veto for protected record access.
+- **DigiDoc**: secure document operations; veto for unauthorized deletions.
+- **DigiTrader**: tool calls for trading; **crucial veto** for real funds.
+- **DroidLynX**: task orchestration; veto for unauthorized external API calls.
+- **VirtuaLynX**: rendering offload + spatial anchors; veto for global map integrity.
+- **Digiworld**: simulation routing; veto if simulated actions incur real-world commitments.
+
+### 1.6 User Stories
+1. **As a security officer**, I need all high-risk commands to be rejected when DAG validation is ambiguous so that funds and sensitive data are protected.
+2. **As an XR user**, I need gesture + voice to be fused in near-real time so that holographic interactions feel instantaneous.
+3. **As a product owner**, I need service routing abstracted so that internal services can be moved without breaking clients.
+4. **As an auditor**, I need immutable, verifiable context objects to trace the origin of any high-risk action.
+
+### 1.7 Acceptance Criteria
+- All context objects are versioned and include DID + device signatures.
+- High-risk actions are blocked unless DAG validation explicitly passes.
+- Fusion engine produces deterministic ordering via UTC + Lamport timestamps.
+- BFF routing decisions are policy-driven and centrally auditable.
+- Remote rendering is offloaded when complexity thresholds are exceeded.
+- Secrets are not embedded in payloads; environment variables are required for credentials.
+
+---
+
+## 2) Architecture Decision Records (ADRs)
+
+### ADR-001: DAG-Anchored Trust Validation
+- **Decision:** Use ChainLynX DAG for identity + compliance validation.
+- **Rationale:** DAG provides parallelized validation with low latency, enabling zero-trust checks at scale.
+- **Consequences:** Requires caching and fail-closed strategies to handle DAG unavailability.
+
+### ADR-002: Plugin Architecture + BFF Router
+- **Decision:** Implement LMCL as plugin core with a BFF routing layer.
+- **Rationale:** Enables modular adapters and consistent client-facing contracts.
+- **Consequences:** Requires strict interface contracts and versioning policies.
+
+### ADR-003: Hybrid Timestamping (UTC + Lamport)
+- **Decision:** Use hybrid timestamping for fusion ordering.
+- **Rationale:** Ensures causal ordering across distributed modalities.
+- **Consequences:** Adds complexity in clock reconciliation; requires drift monitoring.
+
+### ADR-004: Remote Rendering Offload
+- **Decision:** Offload heavy rendering to GPU edge services.
+- **Rationale:** Maintains <20ms motion-to-photon for XR experiences.
+- **Consequences:** Requires WebRTC/SFU streaming reliability and fallbacks.
+
+### ADR-005: ZTA with DID + Device Binding
+- **Decision:** Ephemeral sessions bound to DID + device signatures from VaultLynX.
+- **Rationale:** Prevents session replay and strengthens identity assurance.
+- **Consequences:** Requires rapid re-authentication pathways for UX continuity.
+
+---
+
+## 3) Risk & Tradeoff Analysis (Devil’s Advocate)
+
+1. **DAG Lookup Latency vs. UX:** Strong security may add latency; mitigate with strict TTL caches and prefetch strategies for low-risk paths.
+2. **Fusion Accuracy vs. Speed:** Aggressive fusion time windows risk incorrect context merges; mitigate with modality confidence scoring.
+3. **Remote Offload Reliability:** Dependence on GPU services introduces new failure points; require local fallback modes.
+4. **Compliance Veto False Positives:** Overly strict policies could block legitimate actions; mitigate with human-in-the-loop review queues.
+5. **Privacy vs. Observability:** Detailed audit trails may expose sensitive data; enforce redaction and access controls.
+6. **Carbon-Aware Scheduling Impact:** Green routing might conflict with latency budgets; apply only to non-XR paths.
+
+---
+
+## 4) Governance Anchors (Human Oversight)
+
+1. **High-Risk Financial Actions (DigiTrader):** Mandatory human approval before execution.
+2. **Protected Record Access (DigiLawyer/DigiDoc):** Human review for access overrides.
+3. **Global Spatial Map Updates (VirtuaLynX):** Human approval to prevent integrity drift.
+4. **External API Invocation (DroidLynX):** Human approval for new external endpoints.
+
+---
+
+## 5) Implementation Guidance (Non-Code)
+
+### Branch Naming Suggestion
+Use Gitflow format: `{layer}/{hub}/{module}/{tag}`.
+- Example: `middleware/lmcl/blueprint/feature`
+
+### Brand Token Compliance
+- Ruby Red: `#9B111E`
+- Yellow Gold: `#FFD700`
+- Emerald: `#50C878`
+
+### Code Integrity Mandates
+- All secrets via environment variables.
+- Explicit error handling required in every adapter and validator.
+- Steganographic watermarking embedded in payloads for forensic traceability.
+
+---
+
+## 6) Phase Plan Summary
+
+1. **Phase 1 (LMCL-Input):** Define ContextObject_v1.0 and adapter normalization interfaces.
+2. **Phase 2 (LMCL-Core):** Implement trust validator, fusion engine, and BFF router policies.
+3. **Phase 3 (LMCL-Services):** Render offload and agent task orchestration with audit hooks.
+
+---
+
+## 7) Open Questions
+- Which DAG node endpoints and SLA targets are authoritative for ChainLynX lookups?
+- What are the explicit compliance policies for high-risk actions in each service?
+- Which Postman schemas define the canonical API contracts for each microservice?


### PR DESCRIPTION
### Motivation
- Provide a governance-grade design blueprint for the LynxVerse Multimodal Context Layer (LMCL) to define how multimodal context fusion and DAG-anchored trust/veto are to be implemented across the EternaLynX ecosystem.
- Capture architectural constraints (DAGNet trust lookups, plugin/BFF pattern, Redis/Postgres state, VaultLynX DID binding, and low-latency offload) and align decisions with the DPPM reasoning loop.
- Record decision rationale, failure-mode analysis, and human oversight anchors to guide downstream engineering without including production code. 

### Description
- Add a single specification file `docs/specs/lmcl-blueprint.md` containing the technical specification, DPPM decomposition, and the canonical `ContextObject_v1.0` schema. 
- Include LMCL module responsibilities covering `LMCL-Input` adapters, `LMCL-Core` (`DagTrustValidator`, `FusionEngine`, `Router`), and `LMCL-Services` (`RenderOffload`, `AgentTaskOrchestrator`).
- Add Architecture Decision Records (ADRs) for DAG-anchored validation, plugin + BFF pattern, hybrid timestamping, remote rendering offload, and ZTA with DID/device binding. 
- Provide risk & tradeoff analysis, governance anchors (human veto points), non-code implementation guidance (branch naming format and brand tokens), a three-phase plan, and a list of open questions for integration. 

### Testing
- No automated tests were run because this change is documentation-only and does not modify executable code.
- The spec file `docs/specs/lmcl-blueprint.md` was added to the repository and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698172ea5f94833097076e7a50deb3ed)