### PR TITLE
Add OmniLynX Studio frontend blueprint spec

### DIFF
--- a/docs/specs/omnilynx-studio-frontend-blueprint.md
+++ b/docs/specs/omnilynx-studio-frontend-blueprint.md
@@ -1,0 +1,145 @@
+# OmniLynX Studio Hub Frontend Blueprint (OmniLynX Studio Frontend Blueprint)
+
+## Technical Specification
+
+### Task Intake & Data Stream Alignment
+- **TASK (Linear Issue / NotebookLM Summary):** _Not provided in the request._ The architecture below treats the user prompt as the current intent signal and flags the missing sources as required inputs for final approval.
+- **NotebookLM Summaries:** _Not provided._ Required for trend alignment (e.g., MIT robotics, carbon-aware computing).
+- **Linear Issues:** _Not provided._ Required for authoritative business goal/bug definition.
+- **Amplitude Insights:** _Not provided._ Required to prioritize high-impact usage patterns.
+- **Postman Schemas:** _Not provided._ Required to finalize GraphQL and WebSocket contract boundaries.
+
+### User Stories
+1. **As a creator**, I want a holographic, quantum-themed workspace so that I can perceive depth and state changes at a glance without losing context.
+2. **As a music producer**, I want an AI DJ mixing board with intuitive controls so that I can shape generative output without advanced technical knowledge.
+3. **As a video director**, I want segmented model inputs and real-time monitoring so that long-form generation remains predictable and correctable.
+4. **As an operations lead**, I want micro-frontend isolation so that failures in MusicHubStudio do not cascade into CinemaLynXComposer.
+5. **As a platform engineer**, I want a single `docker compose up` prototype path so that I can run the full UI locally with minimal setup.
+
+### Acceptance Criteria
+1. The frontend architecture is specified in a micro-frontend or highly modular component structure with explicit isolation boundaries for MusicHubStudio and CinemaLynXComposer.
+2. The 3D rendering pipeline is segmented into independent render flows (background grid, dynamic holographic focus layer, UI overlays), with a custom Fresnel-based GLSL shader specified for holographic depth.
+3. The primary prompt input provides real-time metrics (token count, estimated GPU load, processing priority layer) with a clearly defined data contract.
+4. MusicHubStudio exposes six labeled generative controls tied to immediate holographic shader feedback.
+5. CinemaLynXComposer supports four model slots with fields for prompt, reference upload, and status, plus a real-time monitoring dashboard via WebSockets.
+6. Director’s Final Cut Selector includes three outcomes (Final Cut, Variant 1, User Edit Mode) and a one-click Export/Publish action.
+7. All non-trivial 3D and GraphQL logic is specified for heavy commentary, with explicit notes where scientific constraints limit fidelity.
+8. A monorepo layout is defined with `/frontend/omnilynx-studio/...` and a `docker compose up`-compatible workflow.
+9. Design tokens must include Ruby Red (#9B111E), Yellow Gold (#FFD700), and Emerald (#50C878).
+10. Security and integrity requirements mandate environment variables for secrets, explicit error handling, and steganographic watermarking in all media outputs.
+
+### Decomposition (DPPM: Decompose)
+- **Identity & Access Shard:** Authentication gating for MusicHubStudio and CinemaLynXComposer views; permissioned access to export/publish.
+- **Rendering & Interaction Shard:** R3F scene segmentation, custom GLSL holographic shader, gesture/voice interaction placeholders.
+- **Data & Orchestration Shard:** GraphQL query/mutation contracts and WebSocket monitoring channel definitions.
+- **Media Pipeline Shard:** Model slot inputs, status indicators, and Final Cut selection workflow.
+- **Ops & Deployment Shard:** Monorepo layout, Docker Compose wiring, and environment-variable configuration surfaces.
+
+### Constraint Generation (DPPM: Constraints)
+- **Security:**
+  - Steganographic watermarking required for all generated video/audio preview assets.
+  - Explicit error handling for GraphQL and WebSocket failure states (retries, timeouts, user-facing alerts).
+  - Secrets must be injected via environment variables; no hardcoded keys.
+- **Performance:**
+  - 3D render pipeline must isolate layers to prevent UI blocking; target 60 FPS for core interactions.
+  - GraphQL payloads must be minimal, with pagination for any multi-item retrieval.
+  - WebSocket updates must be rate-limited to avoid UI lockups.
+- **Energy Efficiency:**
+  - Carbon-aware scheduling cues must be present for long-running renders.
+  - Provide UI affordance for “Eco Mode” that reduces rendering fidelity.
+
+### 8 Failure Modes Analysis (DPPM: Anticipatory Reflection)
+1. **Post Request Failure:** Prompt submission fails due to payload size → enforce client-side limits and warn user.
+2. **Deliver Request Failure:** API gateway drops GraphQL request → retry with exponential backoff and offline queue.
+3. **Validate Request Failure:** Schema mismatch → surface validation errors with field-level highlighting.
+4. **Update Server State Failure:** Model slot state does not persist → provide client reconciliation and state diff logs.
+5. **Post Reply Failure:** WebSocket message fails to emit → queue telemetry events and fallback to polling.
+6. **Deliver Reply Failure:** WebSocket disconnects mid-session → show reconnection status with grace period.
+7. **Validate Reply Failure:** Consistency score payload invalid → block UI update and flag telemetry event.
+8. **Update Client State Failure:** Render pipeline hits frame drop → degrade shader complexity and log metrics.
+
+### Architecture Plan (DPPM: Plan in Parallel)
+- **Micro-Frontend Isolation**
+  - MusicHubStudio and CinemaLynXComposer are independently built and mounted under OmniLynX Studio Hub shell.
+  - Use strict prop contracts to prevent cascading failures.
+- **Rendering Pipeline**
+  - R3F scene divided into: (1) static holographic grid, (2) dynamic holographic focus elements, (3) UI overlays.
+  - Custom GLSL Fresnel shader applied to all interactive cards, sliders, and status glyphs.
+- **Data Layer**
+  - GraphQL for structured content fetching; WebSockets for monitoring and status streams.
+  - Typed schemas for metrics (token count, GPU load, priority layer) and monitoring metrics (consistency score, error feed).
+- **Interaction Layer**
+  - Gesture and voice placeholders for future integration, with explicit UX affordances.
+
+### Merge (DPPM: Merge)
+The merged blueprint binds modular micro-frontends, segmented rendering, and GraphQL/WebSocket contracts into a single OmniLynX Studio Hub shell, ensuring holographic UX coherence while isolating MusicHubStudio and CinemaLynXComposer failures.
+
+### Frontend Blueprint (Non-Code Architectural Guidance)
+- **Monorepo Layout (Proposed)**
+  - `/frontend/omnilynx-studio/src/components/HolographicShell` (hub shell + render segmentation)
+  - `/frontend/omnilynx-studio/src/components/MusicHubStudio` (AI DJ mixer + 3D visualization)
+  - `/frontend/omnilynx-studio/src/components/CinemaLynXComposer` (segmented model inputs + monitoring)
+  - `/frontend/omnilynx-studio/src/components/DirectorFinalCut` (output selection + publish)
+  - `/frontend/omnilynx-studio/src/components/common/` (tokens, shared layouts, input metrics)
+- **Design Tokens (Brand Compliance)**
+  - Ruby Red: `#9B111E`
+  - Yellow Gold: `#FFD700`
+  - Emerald: `#50C878`
+
+### Implementation Guardrails (No Production Code)
+- All implementation must use React functional components and hooks.
+- R3F scenes must be isolated into distinct render flows.
+- Holographic shader must use Fresnel effect for angle-dependent glow.
+- Dynamic prompt input must show token count, estimated GPU load, and processing priority layer in real time.
+- Micro-frontend boundaries must prevent cascade failure between MusicHubStudio and CinemaLynXComposer.
+- Any scientific limitation (e.g., fully accurate GPU load prediction) must be documented in code comments with simplified fallback logic.
+
+### Branching Recommendation (Gitflow)
+- **Branch format:** `{layer}/{hub}/{module}/{tag}`
+- **Suggested branch:** `frontend/omnilynx-studio/blueprint/feature`
+
+## Architecture Decision Records (ADRs)
+
+### ADR-001: Micro-Frontend Isolation for MusicHubStudio & CinemaLynXComposer
+- **Status:** Proposed
+- **Decision:** Use micro-frontend or strict module boundaries to isolate MusicHubStudio and CinemaLynXComposer.
+- **Context:** Independent release cadence and failure isolation are mandatory for subsystem resilience.
+- **Consequences:** Additional integration overhead but improved fault containment.
+
+### ADR-002: Segmented R3F Rendering Pipeline
+- **Status:** Proposed
+- **Decision:** Segment 3D rendering into discrete flows: static grid, dynamic holographic layer, UI overlays.
+- **Context:** Prevent UI frame drops and enable targeted shader optimization.
+- **Consequences:** Requires careful synchronization of camera state and render timing.
+
+### ADR-003: GraphQL + WebSocket Data Plane
+- **Status:** Proposed
+- **Decision:** Use GraphQL for structured data and WebSockets for live monitoring.
+- **Context:** Large datasets and real-time updates are central to the UI.
+- **Consequences:** Requires strict schema versioning and reconnect logic.
+
+### ADR-004: Holographic Fresnel Shader
+- **Status:** Proposed
+- **Decision:** Apply Fresnel-based holographic shader to all interactive elements.
+- **Context:** Patentable quantum aesthetic requirement.
+- **Consequences:** Shader complexity must be balanced with performance constraints.
+
+## Risk & Tradeoff Analysis (Devil’s Advocate)
+- **Risk:** Overly complex shader reduces FPS.
+  - **Tradeoff:** Provide shader quality tiers and automatic downgrades under load.
+- **Risk:** WebSocket monitoring floods the UI.
+  - **Tradeoff:** Rate limiting and adaptive sampling during heavy loads.
+- **Risk:** Micro-frontend boundaries increase integration costs.
+  - **Tradeoff:** Define shared component contracts and versioned interfaces early.
+- **Risk:** GPU load estimation may be imprecise.
+  - **Tradeoff:** Use heuristic estimates with transparency about accuracy.
+- **Risk:** Carbon-aware scheduling could introduce user confusion.
+  - **Tradeoff:** Provide explicit UI explanation and opt-out controls.
+
+## Governance Anchors (Human Oversight)
+1. **Shader Review Gate:** Human approval required for any changes to holographic shader parameters and Fresnel coefficients.
+2. **Data Contract Approval:** Human approval required before GraphQL schema or WebSocket payload changes.
+3. **Release Isolation Review:** Human approval required when adjusting micro-frontend boundary contracts.
+4. **Security & Watermarking Audit:** Human approval required for any change to steganographic watermarking pipeline.
+5. **Export/Publish Compliance:** Human approval required for changes to the Rights & Monetization Engine trigger.
+


### PR DESCRIPTION
### Motivation
- Provide a single-source architectural blueprint for the OmniLynX Studio Hub frontend that codifies micro-frontend boundaries, a segmented R3F rendering pipeline with a Fresnel-based holographic shader, GraphQL/WebSocket data contracts, and governance anchors to guide implementation.

### Description
- Add `docs/specs/omnilynx-studio-frontend-blueprint.md` containing technical specification, user stories, acceptance criteria, the DPPM decomposition/plan/merge workflow, constraint and failure-mode analyses, ADRs, risk/tradeoff analysis, governance anchors, design tokens, and a recommended monorepo layout and branch format.
- The spec prescribes rendering and interaction guardrails (R3F scene segmentation, Fresnel shader requirements), data-plane choices (`GraphQL` + WebSockets), micro-frontend isolation for `MusicHubStudio` and `CinemaLynXComposer`, and operational constraints (env-var secrets, steganographic watermarking, eco-mode).

### Testing
- Automated tests: none executed because this is a documentation/specification-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981724f703883309300b8e8d8d129ce)