### PR TITLE
Add WalletLynX-Service v1.0 architectural specification

### DIFF
--- a/docs/specs/walletlynx-service-v1.md
+++ b/docs/specs/walletlynx-service-v1.md
@@ -1,0 +1,194 @@
+# WalletLynX-Service v1.0 — Architectural Specification (Non-Implementation)
+
+> Role notice: This document provides **architecture, rationale, and governance** only. It intentionally avoids production-ready code. Downstream engineers should implement based on this spec.
+
+## 0) Inputs & Data Stream Alignment
+
+### Provided Inputs
+- **User prompt**: “MarketLynX/FinanciaLynX Core Backend (WalletLynX Focus) v1.0” requirements and module definitions.
+- **Repo context**: No existing implementation artifacts beyond a README.
+
+### Missing Required Inputs (Blocked Signals)
+To comply with the mandatory synthesis requirement, the following streams are **missing** and must be supplied before implementation:
+- **NotebookLM Summaries** (global trends) — *Not provided.*
+- **Linear Issues** (intent signal) — *Not provided.*
+- **Amplitude Insights** (behavioral prioritization) — *Not provided.*
+- **Postman Schemas** (API contracts) — *Not provided.*
+
+**Interim Policy**: This document proceeds with **explicit placeholders** and conservative assumptions. Implementation must not proceed until these inputs are attached and reviewed.
+
+---
+
+## 1) Technical Specification
+
+### 1.1 Scope & Non-Goals
+**Scope**: A **standalone**, modular Node.js/TypeScript microservice, located at `/backend/walletlynx-service`, responsible for:
+- User balances and token transactions for **DigiUSD** (stablecoin) and **Unicoin** (governance token).
+- Immutable ledger persistence via **PostgreSQL + Prisma**.
+- Redis for caching/session.
+- Kafka producer/consumer for async trade and compliance events.
+- SecuriLynX proxy adapter for KYC/AML gating.
+
+**Non-Goals**: No blockchain integration implementation, no production-ready code, no UI, no gateway implementation.
+
+### 1.2 Architectural Mandates
+- **Layered Architecture**: Separate API layer, domain services, data access (Prisma), and external adapters (Kafka, Redis, SecuriLynX).
+- **Zero-Trust Identity**: Canonical user identity comes **only** from `X-Lynx-User-ID` header from upstream gateway.
+- **Immutability & Auditability**: Ledger entries are append-only. No destructive edits.
+- **No Secrets in Code**: Every secret is **environment-driven**.
+- **Brand Compliance Tokens**: Ruby Red `#9B111E`, Yellow Gold `#FFD700`, Emerald `#50C878` are referenced for any configuration or documentation used by downstream UI/ops dashboards.
+
+### 1.3 Required Services & Modules
+**A) Ledger & Account Management**
+- Schema objects:
+  - `UserFinancialIdentity` (VaultLynX_ID, trust_score, account_status).
+  - `AccountBalance` (user_id, token_type, balance) with unique constraint `(user_id, token_type)`.
+  - `TransactionLedger` (tx_id, user_id, type, amount, token_type, status, blockchain_hash).
+- API endpoints (REST):
+  - `GET /api/v1/wallet/balance`
+  - `POST /api/v1/wallet/transfer` (must check SecuriLynX if amount > 5,000 DigiUSD).
+
+**B) Token Protocol & Governance**
+- DigiUSD:
+  - Mint/Burn services (internal-only; gated by RBAC and admin service ID in header).
+  - Ledger + AccountBalance updates are mandatory.
+- Unicoin:
+  - StakingService, DAO_ValidatorService.
+  - `GET /api/v1/token/governance/check-stake-eligibility` returning boolean based on local balance.
+
+**C) Quantum AI Trade Nexus**
+- `POST /api/v1/trade/signal` to Kafka `LYNX_TRADE_QUEUE` and return **202 Accepted**.
+- DAG orchestration: classify trade requests as **Dependent** or **Independent** for parallel execution.
+- Finality layer: persist confirmation hash to `TransactionLedger`.
+
+### 1.4 User Stories & Acceptance Criteria
+
+**US-1**: As a user, I want to view balances for DigiUSD and Unicoin.
+- **AC-1**: Request uses `X-Lynx-User-ID` and returns balances from `AccountBalance` scoped to that user.
+- **AC-2**: Ledger integrity remains unchanged (no writes on read).
+
+**US-2**: As a user, I want to transfer DigiUSD with compliance checks.
+- **AC-1**: If amount > 5,000 DigiUSD, SecuriLynX proxy check must be called before any ledger entry.
+- **AC-2**: TransactionLedger entry is created with `PENDING` then updated to `COMMITTED` upon success.
+
+**US-3**: As a FinanciaLynX admin service, I want to mint/burn DigiUSD.
+- **AC-1**: Requests without correct admin role are rejected.
+- **AC-2**: Mint/Burn creates immutable ledger records and updates balances atomically.
+
+**US-4**: As the Trading Nexus, I want to enqueue trade signals asynchronously.
+- **AC-1**: API responds within 50ms under normal load with status 202.
+- **AC-2**: Message is published to Kafka topic `LYNX_TRADE_QUEUE` with trace metadata.
+
+**US-5**: As governance, I need eligibility checks for staking.
+- **AC-1**: DAO eligibility returns boolean derived from Unicoin balance threshold.
+
+### 1.5 DPPM Workflow (Mandatory)
+
+#### Decomposition (Identity, Commerce, Data, Enterprise Shards)
+- **Identity**: Zero-trust header parsing, RBAC validation, SecuriLynX adapter.
+- **Commerce**: Mint/Burn/Transfer/Trade operations and DAG orchestration.
+- **Data**: Prisma schema, immutable ledger design, Redis cache keys.
+- **Enterprise**: Kafka integration, observability, audit trails.
+
+#### Plan in Parallel
+- **Identity**: Define header schema, RBAC roles, and compliance thresholds.
+- **Commerce**: Model token operations and required ledger states.
+- **Data**: Build Prisma schema, migration strategy, and DB constraints.
+- **Enterprise**: Define Kafka contracts, retry policy, tracing.
+
+#### Merge
+- Consolidate service boundaries and message contracts.
+- Validate compliance triggers and audit trail coverage.
+- Ensure bounded contexts prevent cross-layer leakage.
+
+### 1.6 Constraint Generation
+- **Security**: Steganographic watermarking required in transaction metadata for audit traceability.
+- **Performance**: 50ms P95 for POST /trade/signal. 150ms P95 for /wallet/balance. 300ms P95 for /wallet/transfer.
+- **Energy Efficiency**: Carbon-aware scheduling for DAG execution; prioritize off-peak batch processing when not latency-sensitive.
+
+### 1.7 “8 Failure Modes” Anticipatory Reflection
+1. **Post Request**: malformed headers → reject with explicit error.
+2. **Deliver Request**: gateway latency → enforce idempotency keys.
+3. **Validate Request**: RBAC mismatch → deny and audit log.
+4. **Update Server State**: partial ledger update → enforce transaction boundaries.
+5. **Post Reply**: response serialization failure → return minimal error with trace ID.
+6. **Deliver Reply**: downstream client timeout → ensure retries are safe.
+7. **Validate Reply**: client rejects stale state → include versioning in payload.
+8. **Update Client State**: race conditions in UI → provide monotonic ledger sequence.
+
+### 1.8 Configuration Snippets (Non-Executable)
+- Environment variables: `DATABASE_URL`, `REDIS_URL`, `KAFKA_BROKER_URLS`, `SECURILYNX_URL`, `ADMIN_SERVICE_ID`, `PORT`.
+- Docker: separate services for Postgres, Redis, Kafka, and WalletLynX service.
+
+---
+
+## 2) Architecture Decision Records (ADRs)
+
+### ADR-001: Prisma + PostgreSQL for immutable ledger
+**Decision**: Use Prisma ORM over PostgreSQL.
+**Why**: Strong schema enforcement, transactional guarantees, and query safety for auditability.
+**Alternatives**: Knex, Sequelize.
+**Consequences**: Requires strict migration governance and immutable ledger policies.
+
+### ADR-002: Kafka for asynchronous trade processing
+**Decision**: Use Kafka for trade signals and compliance events.
+**Why**: High throughput, partition ordering for dependent transactions, and replay capability.
+**Alternatives**: RabbitMQ, SQS.
+**Consequences**: Operational complexity and strict message schema governance required.
+
+### ADR-003: DAG execution model for independent transactions
+**Decision**: Classify trades into Dependent vs Independent for parallel execution.
+**Why**: Minimizes latency in high-frequency trading signals while preserving correctness.
+**Alternatives**: Sequential execution.
+**Consequences**: Requires conflict detection and resource locking strategy.
+
+### ADR-004: Zero-trust user identity via header
+**Decision**: Trust only `X-Lynx-User-ID` from the gateway.
+**Why**: Centralized auth simplifies microservice boundaries and reduces credential spread.
+**Alternatives**: Internal auth tokens.
+**Consequences**: Gateway must be hardened; header spoofing must be blocked at edge.
+
+---
+
+## 3) Risk & Tradeoff Analysis (Devil’s Advocate)
+
+- **Risk**: Kafka backlog causes stale trade execution.
+  - **Tradeoff**: Increased throughput vs. operational complexity. Mitigation: backpressure and DLQ policy.
+- **Risk**: DAG parallelism introduces race conditions.
+  - **Tradeoff**: Latency reduction vs. correctness. Mitigation: deterministic resource locking and conflict graph.
+- **Risk**: Compliance adapter latency blocks transfers.
+  - **Tradeoff**: Regulatory safety vs. user experience. Mitigation: asynchronous pre-clearance for high-value accounts.
+- **Risk**: Immutable ledger growth increases DB costs.
+  - **Tradeoff**: Auditability vs. storage. Mitigation: partitioned tables, archival strategy.
+
+---
+
+## 4) Governance Anchors (Human Oversight)
+
+- **Anchor G-1**: Approval required for any change to ledger schema or retention policy.
+- **Anchor G-2**: Approval required for any change to RBAC rules or admin service ID.
+- **Anchor G-3**: Approval required for any change to compliance thresholds or SecuriLynX adapter behavior.
+- **Anchor G-4**: Approval required for DAG conflict classification rules.
+- **Anchor G-5**: Approval required for any change to external message schemas (Kafka).
+
+---
+
+## 5) Branching Recommendation
+- **Suggested branch**: `platform/walletlynx-service/architecture/feature` (format: `{layer}/{hub}/{module}/{tag}`; tag = `feature`).
+
+---
+
+## 6) Implementation Guidance (Non-Code)
+
+- **Environment Variables**: All secrets and endpoints must be in environment variables; no inline strings.
+- **Explicit Error Handling**: Every async boundary must define typed error responses.
+- **Steganographic Watermarking**: Embed watermark in transaction metadata to prove provenance during audits.
+- **Interface Contracts**: Must be generated from Postman schemas once provided.
+
+---
+
+## 7) Open Questions / Required Follow-ups
+- Provide **Linear Issue ID** and **NotebookLM summary** to validate business intent.
+- Provide **Amplitude insights** to prioritize which flows get caching vs. direct DB reads.
+- Provide **Postman schemas** to lock API request/response structure.
+


### PR DESCRIPTION
### Motivation
- Provide a non-implementation architectural blueprint for a standalone WalletLynX-Service to guide downstream engineering work and enforce high-level mandates such as Zero-Trust identity, immutable ledger design, and clear module boundaries.
- Capture the DPPM (Decompose, Plan in Parallel, Merge) workflow, risk analysis (8 failure modes), and ADRs to ensure the design is auditable and amenable to future regulatory scrutiny.
- Surface missing inputs and blockers (NotebookLM summaries, Linear issue, Amplitude insights, Postman schemas) as explicit placeholders to prevent premature implementation without required signals.

### Description
- Add a comprehensive architecture doc at `docs/specs/walletlynx-service-v1.md` that defines scope, non-goals, required modules, and high-level constraints for the WalletLynX microservice.
- Specify database schema objects and persistence patterns (Prisma + PostgreSQL) including `UserFinancialIdentity`, `AccountBalance`, and `TransactionLedger`, and list key API contracts like `GET /api/v1/wallet/balance`, `POST /api/v1/wallet/transfer`, `POST /api/v1/trade/signal`, and `GET /api/v1/token/governance/check-stake-eligibility` as design targets.
- Describe integration adapters and infrastructure requirements (Redis, Kafka topic `LYNX_TRADE_QUEUE`, SecuriLynX proxy adapter, RBAC/admin gating for Mint/Burn), the DAG-based trade orchestration concept, and the finality requirement to record `blockchain_hash` in ledger entries.
- Include ADRs, constraint generation (performance and security targets), the DPPM workflow, risk & tradeoff analysis, governance anchors, branching recommendation (`platform/walletlynx-service/architecture/feature`), and non-executable implementation guidance (environment variables and Docker recommendations). 

### Testing
- This change is documentation-only and did not include automated unit, integration, or CI tests. 
- No automated tests were run as part of this change (document added and committed to the repo).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981641402648330b4276e519d8dc8c0)